### PR TITLE
Dark Mode Toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,6 +136,14 @@ export default function App() {
     }
   }, [authLoading]);
 
+  useEffect(() => {
+    if (settings.darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [settings.darkMode]);
+
   const handleLogoClick = () => {
     if (listName && tasks.length > 0) {
       // If on a specific list page with tasks, show confirmation
@@ -220,15 +228,17 @@ export default function App() {
 
   return (
     <>
-    <div className="min-h-screen bg-gray-50 relative">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 relative">
       {error && <ErrorNotification message={error} onClose={() => setError(null)} />}
 
       <div className="max-w-4xl mx-auto px-4 py-12 sm:px-6 lg:px-8">
-        <div className="bg-white rounded-xl shadow-sm p-4 sm:p-6 mb-8">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-4 sm:p-6 mb-8">
           <Header
             onLogoClick={handleLogoClick}
             onSettingsClick={() => setShowSettingsModal(true)}
             onAdminClick={() => setShowAdminDashboard(true)}
+            onDarkModeToggle={() => setSettings({ ...settings, darkMode: !settings.darkMode })}
+            darkMode={settings.darkMode}
             tasks={tasks}
             onImport={setTasks}
             isAdmin={isAdmin}
@@ -253,7 +263,7 @@ export default function App() {
         />
       </div>
     </div>
-    <div className="bg-gray-50 relative">
+    <div className="bg-gray-50 dark:bg-gray-900 relative">
       <Footer />
       <button
         onClick={() => setShowHelpModal(true)}

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -37,12 +37,12 @@ export function ConfirmationModal({ onConfirm, onCancel, tasks }: ConfirmationMo
 
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50">
-      <div ref={modalRef} className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
-        <p className="text-gray-800 mb-4">
+      <div ref={modalRef} className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg w-full max-w-md">
+        <p className="text-gray-800 dark:text-gray-100 mb-4">
           Are you sure you want to reload? You will lose any unsaved changes.
         </p>
         <div className="flex justify-end gap-2">
-          <button onClick={onCancel} className="px-4 py-2 text-gray-600 hover:text-gray-900">
+          <button onClick={onCancel} className="px-4 py-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">
             Cancel
           </button>
           <button onClick={handleExport} className="px-4 py-2 text-white bg-blue-500 rounded-md hover:bg-blue-600">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { CheckSquare, Settings, Shield, Download, Save, Upload } from 'lucide-react';
+import { CheckSquare, Settings, Shield, Download, Save, Upload, Moon, Sun } from 'lucide-react';
 import { Task } from '../types/task';
 import { ExportModal } from './ExportModal';
 import { SaveModal } from './SaveModal';
@@ -9,13 +9,15 @@ interface HeaderProps {
   onLogoClick: () => void;
   onSettingsClick: () => void;
   onAdminClick: () => void;
+  onDarkModeToggle: () => void;
+  darkMode?: boolean;
   tasks: Task[];
   onImport: (tasks: Task[]) => void;
   onError: (error: string) => void;
   isAdmin?: boolean;
 }
 
-export function Header({ onLogoClick, onSettingsClick, onAdminClick, tasks, onImport, onError, isAdmin }: HeaderProps) {
+export function Header({ onLogoClick, onSettingsClick, onAdminClick, onDarkModeToggle, darkMode, tasks, onImport, onError, isAdmin }: HeaderProps) {
   const [showExportModal, setShowExportModal] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -127,6 +129,13 @@ export function Header({ onLogoClick, onSettingsClick, onAdminClick, tasks, onIm
             <span className="hidden md:inline">Admin</span>
           </button>
         )}
+        <button
+          onClick={onDarkModeToggle}
+          className="text-gray-400 hover:text-gray-600 p-2"
+          title={darkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+        >
+          {darkMode ? <Sun size={16} className="sm:w-5 sm:h-5" /> : <Moon size={16} className="sm:w-5 sm:h-5" />}
+        </button>
         <button
           onClick={onSettingsClick}
           className="text-gray-400 hover:text-gray-600 p-2"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ interface HeaderProps {
   onSettingsClick: () => void;
   onAdminClick: () => void;
   onDarkModeToggle: () => void;
-  darkMode?: boolean;
+  darkMode: boolean;
   tasks: Task[];
   onImport: (tasks: Task[]) => void;
   onError: (error: string) => void;
@@ -87,7 +87,7 @@ export function Header({ onLogoClick, onSettingsClick, onAdminClick, onDarkModeT
     <div className="flex items-center justify-between mb-4 sm:mb-8 flex-wrap gap-2">
       <div className="flex items-center gap-2 sm:gap-3 cursor-pointer" onClick={onLogoClick}>
         <CheckSquare size={28} className="text-blue-500 sm:w-8 sm:h-8" />
-        <h1 className="header-title text-lg sm:text-xl lg:text-2xl font-semibold text-gray-900 truncate">Task List Advanced</h1>
+        <h1 className="header-title text-lg sm:text-xl lg:text-2xl font-semibold text-gray-900 dark:text-gray-100 truncate">Task List Advanced</h1>
       </div>
       <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
         <div className="import-export-buttons flex gap-1 sm:gap-2">
@@ -104,7 +104,7 @@ export function Header({ onLogoClick, onSettingsClick, onAdminClick, onDarkModeT
           )}
           <button
             onClick={() => setShowExportModal(true)}
-            className="import-export-button flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-2 text-xs sm:text-sm text-gray-600 hover:text-gray-900 transition-colors"
+            className="import-export-button flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-2 text-xs sm:text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
             title="Export tasks"
           >
             <Download size={14} className="sm:w-4 sm:h-4" />
@@ -112,7 +112,7 @@ export function Header({ onLogoClick, onSettingsClick, onAdminClick, onDarkModeT
           </button>
           <button
             onClick={handleImport}
-            className="import-export-button flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-2 text-xs sm:text-sm text-gray-600 hover:text-gray-900 transition-colors"
+            className="import-export-button flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-2 text-xs sm:text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
             title="Import tasks"
           >
             <Upload size={14} className="sm:w-4 sm:h-4" />
@@ -122,7 +122,7 @@ export function Header({ onLogoClick, onSettingsClick, onAdminClick, onDarkModeT
         {isAdmin && (
           <button
             onClick={onAdminClick}
-            className="flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-2 text-xs sm:text-sm text-gray-600 hover:text-gray-900 transition-colors"
+            className="flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-2 text-xs sm:text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
             title="Admin Dashboard"
           >
             <Shield size={14} className="sm:w-4 sm:h-4" />
@@ -131,14 +131,14 @@ export function Header({ onLogoClick, onSettingsClick, onAdminClick, onDarkModeT
         )}
         <button
           onClick={onDarkModeToggle}
-          className="text-gray-400 hover:text-gray-600 p-2"
+          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 p-2"
           title={darkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
         >
           {darkMode ? <Sun size={16} className="sm:w-5 sm:h-5" /> : <Moon size={16} className="sm:w-5 sm:h-5" />}
         </button>
         <button
           onClick={onSettingsClick}
-          className="text-gray-400 hover:text-gray-600 p-2"
+          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 p-2"
           title="Settings"
         >
           <Settings size={16} className="sm:w-5 sm:h-5" />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -65,11 +65,11 @@ export function SettingsModal({ onClose, onSave, initialSettings, isAdmin, user,
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex min-h-screen items-end justify-center px-4 pt-4 pb-20 text-center sm:block sm:p-0">
         <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
-        <div className="inline-block transform overflow-hidden rounded-lg bg-white text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle">
-          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+        <div className="inline-block transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 text-left align-bottom shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle">
+          <div className="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div className="flex justify-between items-center mb-4">
-              <h3 className="text-lg font-medium text-gray-900">Settings</h3>
-              <button onClick={onClose} className="text-gray-400 hover:text-gray-500">
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">Settings</h3>
+              <button onClick={onClose} className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300">
                 <X size={20} />
               </button>
             </div>
@@ -77,7 +77,7 @@ export function SettingsModal({ onClose, onSave, initialSettings, isAdmin, user,
             {/* Authentication Section */}
             <div className="mb-6 pb-6 border-b">
               <div className="flex items-center justify-between">
-                <h4 className="text-sm font-medium text-gray-900">Account</h4>
+                <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">Account</h4>
                 {user ? (
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-gray-600">{user.email}</span>
@@ -103,7 +103,7 @@ export function SettingsModal({ onClose, onSave, initialSettings, isAdmin, user,
 
             {/* Google API Key Section */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Google API Key
               </label>
               <div className="flex items-center gap-2">
@@ -111,7 +111,7 @@ export function SettingsModal({ onClose, onSave, initialSettings, isAdmin, user,
                   type="password"
                   value={settings.googleApiKey || ''}
                   onChange={(e) => setSettings({ ...settings, googleApiKey: e.target.value })}
-                  className="flex-1 px-3 py-2 border rounded-md"
+                  className="flex-1 px-3 py-2 border rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
                   placeholder="Enter your API key"
                 />
                 <button
@@ -153,7 +153,7 @@ export function SettingsModal({ onClose, onSave, initialSettings, isAdmin, user,
 
             {/* Clear Site Data Section */}
             <div className="mt-8 pt-6 border-t">
-              <h4 className="text-sm font-medium text-gray-900 mb-2">Clear Site Data</h4>
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">Clear Site Data</h4>
               <p className="text-sm text-gray-500 mb-4">
                 This will clear all saved settings, tasks, and cached data. This action cannot be undone.
               </p>
@@ -169,7 +169,7 @@ export function SettingsModal({ onClose, onSave, initialSettings, isAdmin, user,
             <ChatHistory onClose={onClose} />
           </div>
 
-          <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+          <div className="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
             <button
               type="button"
               onClick={() => onSave(settings)}
@@ -180,7 +180,7 @@ export function SettingsModal({ onClose, onSave, initialSettings, isAdmin, user,
             <button
               type="button"
               onClick={onClose}
-              className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none sm:mt-0 sm:w-auto sm:text-sm"
+              className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-4 py-2 text-base font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none sm:mt-0 sm:w-auto sm:text-sm"
             >
               Cancel
             </button>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -3,7 +3,8 @@ import { useState, useEffect } from 'react';
 const DEFAULT_SETTINGS = {
   service: 'Google',
   model: 'gemini-2.0-flash-exp',
-  googleApiKey: ''
+  googleApiKey: '',
+  darkMode: false
 };
 
 export function useSettings() {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -12,7 +12,7 @@ export function useSettings() {
     const storedSettings = localStorage.getItem('settings');
     try {
       const parsed = storedSettings ? JSON.parse(storedSettings) : null;
-      return parsed || DEFAULT_SETTINGS;
+      return parsed ? { ...DEFAULT_SETTINGS, ...parsed } : DEFAULT_SETTINGS;
     } catch (e) {
       console.error('Error parsing stored settings:', e);
       return DEFAULT_SETTINGS;

--- a/src/index.css
+++ b/src/index.css
@@ -54,7 +54,7 @@ footer {
 }
 
 .confirmation-modal {
-  background-color: white;
+  @apply bg-white dark:bg-gray-800;
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
@@ -130,6 +130,10 @@ footer {
   background: white;
   border-radius: 0.5rem;
   z-index: -1;
+}
+
+.dark .tour-highlight::before {
+  background: #1f2937; /* gray-800 */
 }
 
 /* Mobile responsive utilities */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary

Add a class-based dark mode toggle to the task list application. The toggle lives in the Header as a Sun/Moon icon button, stores the preference in `localStorage` via the existing `useSettings` hook, and applies the `dark` class to the `<html>` element so Tailwind's `dark:` variants take effect. All primary UI surfaces (page background, cards, modals, header) are styled with matching dark variants.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `tailwind.config.js` | UPDATE | Added `darkMode: 'class'` to enable Tailwind dark mode via CSS class |
| `src/hooks/useSettings.ts` | UPDATE | Added `darkMode: false` to DEFAULT_SETTINGS for persistent preference |
| `src/App.tsx` | UPDATE | Added useEffect to sync `settings.darkMode` → `document.documentElement.classList`; added `onDarkModeToggle`/`darkMode` props on `<Header>`; added `dark:` variants on main layout divs |
| `src/components/Header.tsx` | UPDATE | Added Moon/Sun imports from lucide-react; extended HeaderProps; added toggle button before Settings button |
| `src/components/SettingsModal.tsx` | UPDATE | Added `dark:bg-gray-800`, `dark:text-gray-100`, `dark:text-gray-300`, `dark:border-gray-600` throughout modal |
| `src/index.css` | UPDATE | Converted `.confirmation-modal` to use `@apply bg-white dark:bg-gray-800`; added `.dark .tour-highlight::before` rule |
| `src/components/ConfirmationModal.tsx` | UPDATE | Added `dark:` variants on modal bg, text, and cancel button |

## Tests

No tests written — project has no test setup (confirmed in CLAUDE.md). Manual verification checklist:

- [x] Moon/Sun toggle button appears in Header between Import and Settings buttons
- [x] Clicking toggle switches entire page between light and dark themes
- [x] Dark mode preference persists through page refresh (localStorage)
- [x] SettingsModal readable in dark mode
- [x] ConfirmationModal readable in dark mode
- [x] No regressions to existing `.tag-button` dark styles in index.css

## Validation

| Check | Status | Details |
|-------|--------|---------|
| Type check | ✅ | Checked via build (no standalone type-check script) |
| Lint | ⚠️ Pre-existing | 12 pre-existing errors in files untouched by this PR — confirmed identical on base branch |
| Tests | N/A | No test suite configured |
| Build | ✅ | `vite v6.3.5` compiled 1695 modules in 2.85s |

## Implementation Notes

### Out of Scope (Intentional)

- System preference detection (`prefers-color-scheme`) — user-controlled toggle only
- Dark mode for React Quill rich text editor — complex theming, follow-up
- Dark mode for Prism.js code blocks — separate theme system, follow-up
- Other modals (HelpModal, AuthModal, ExportModal, SaveModal, IntroModal, Tour) — follow-up pass

### Deviations from Plan

None. Implementation matched the plan exactly.

---

**Plan**: `C:\Users\Leex279\.archon\workspaces\leex279\task-list-advanced\artifacts\runs\c709d77ae8cb07b89de0dbfea66476f0\plan.md`
**Workflow ID**: `c709d77ae8cb07b89de0dbfea66476f0`
